### PR TITLE
Update widget.js

### DIFF
--- a/app/widgets/ytPlayer/controllers/widget.js
+++ b/app/widgets/ytPlayer/controllers/widget.js
@@ -15,7 +15,7 @@ exports.play = function(id) {
 function getVideo(id) {
     var client = Ti.Network.createHTTPClient();
     client.onload = function () {
-        var json = decodeURIComponent(decodeURIComponent(decodeURIComponent(decodeURIComponent(this.responseText.substring(4, this.responseText.length)))));
+	var json = (this.responseText.substring(4, this.responseText.length));
         var response = JSON.parse(json);
         var video = response.content.video;
         var isHighQuality = video['fmt_stream_map'] != null;


### PR DESCRIPTION
The old 
         var json = decodeURIComponent(decodeURIComponent(decodeURIComponent(decodeURIComponent(this.responseText.substring(4, this.responseText.length)))));

no longer works , its produces an invalid json 

so to make it work just simply replace it with

```
    var json = (this.responseText.substring(4, this.responseText.length));
```
