### PR TITLE
fixed one of properties name for createVideoPlayer in playVideo()

### DIFF
--- a/Resources/ytPlayer.js
+++ b/Resources/ytPlayer.js
@@ -27,7 +27,7 @@ function playVideo(url) {
         fullscreen: true,
         autoplay: true,
         scalingMode: Ti.Media.VIDEO_SCALING_ASPECT_FIT,
-        mediaControlMode: Ti.Media.VIDEO_CONTROL_DEFAULT
+        mediaControlStyle: Ti.Media.VIDEO_CONTROL_DEFAULT
     });
     videoPlayer.addEventListener("complete", function() {
         Ti.API.info("video player complete");


### PR DESCRIPTION
Changed property name from mediaControlMode to mediaControlStyle. The previous worked (magically) but prevented change of controls style (e.g. to VIDEO_CONTROL_NONE).
